### PR TITLE
split ompl_app graphics into separate lib

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (OMPL_BUILD_DEMOS)
-    set(OMPLAPP_DEMO_LIBRARIES ${OMPLAPP_LIBRARIES} ompl ompl_app)
+    set(OMPLAPP_DEMO_LIBRARIES ${OMPLAPP_LIBRARIES} ompl ompl_app_base)
 
     macro(add_omplapp_demo demo_name)
       add_executable(${ARGV})

--- a/src/omplapp/CMakeLists.txt
+++ b/src/omplapp/CMakeLists.txt
@@ -1,19 +1,24 @@
 # create a library with the common parts of applications
-file(GLOB_RECURSE OMPLAPP_SRC *.cpp)
+file(GLOB OMPLAPP_BASE_SRC geometry/*.cpp geometry/detail/*.cpp apps/*.cpp apps/detail/*.cpp)
+file(GLOB OMPLAPP_GUI_SRC apps/graphical/*.cpp graphics/*.cpp graphics/detail/*.cpp)
 
 if(MSVC)
-    add_library(ompl_app STATIC ${OMPLAPP_SRC})
+    add_library(ompl_app_base STATIC ${OMPLAPP_BASE_SRC})
+    add_library(ompl_app STATIC ${OMPLAPP_GUI_SRC})
 else(MSVC)
-    add_library(ompl_app SHARED ${OMPLAPP_SRC})
+    add_library(ompl_app_base SHARED ${OMPLAPP_BASE_SRC})
+    add_library(ompl_app SHARED ${OMPLAPP_GUI_SRC})
 endif(MSVC)
 
 if(TARGET assimp)
+    add_dependencies(ompl_app_base assimp)
     add_dependencies(ompl_app assimp)
 endif()
 if(TARGET fcl)
-    add_dependencies(ompl_app fcl)
+    add_dependencies(ompl_app_base fcl)
 endif()
-target_link_libraries(ompl_app ompl ${OMPLAPP_LIBRARIES})
+target_link_libraries(ompl_app_base ompl ${OMPLAPP_LIBRARIES})
+target_link_libraries(ompl_app ompl_app_base ompl ${OMPLAPP_LIBRARIES})
 
 if(WIN32)
   if(MSVC10 OR MINGW)
@@ -22,20 +27,27 @@ if(WIN32)
     set(WIN32_STATIC_LIBRARY_FLAGS "psapi.lib ws2_32.lib glu32.lib opengl32.lib &quot;${ASSIMP_LIBRARY}&quot; &quot;${PQP_LIBRARY}&quot;")
   endif(MSVC10 OR MINGW)
   set_target_properties(ompl_app PROPERTIES VERSION "${OMPLAPP_VERSION}" STATIC_LIBRARY_FLAGS "${WIN32_STATIC_LIBRARY_FLAGS}")
+  set_target_properties(ompl_app_base PROPERTIES VERSION "${OMPLAPP_VERSION}" STATIC_LIBRARY_FLAGS "${WIN32_STATIC_LIBRARY_FLAGS}")
   if(MINGW)
     set_target_properties(ompl_app PROPERTIES LINK_FLAGS "-Wl,--export-all-symbols")
+    set_target_properties(ompl_app_base PROPERTIES LINK_FLAGS "-Wl,--export-all-symbols")
   endif(MINGW)
 else(WIN32)
   set_target_properties(ompl_app PROPERTIES VERSION "${OMPLAPP_VERSION}" SOVERSION "${OMPLAPP_ABI_VERSION}")
+  set_target_properties(ompl_app_base PROPERTIES VERSION "${OMPLAPP_VERSION}" SOVERSION "${OMPLAPP_ABI_VERSION}")
 endif(WIN32)
 
-install(TARGETS ompl_app
+install(TARGETS ompl_app ompl_app_base
     DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT omplapp)
 if(NOT MSVC)
     add_custom_command(TARGET ompl_app POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:ompl_app>"
         "${CMAKE_CURRENT_SOURCE_DIR}/../../ompl/py-bindings/ompl/app/libompl_app${CMAKE_SHARED_LIBRARY_SUFFIX}"
+        WORKING_DIRECTORY "${LIBRARY_OUTPUT_PATH}")
+    add_custom_command(TARGET ompl_app_base POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:ompl_app_base>"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../ompl/py-bindings/ompl/app/libompl_app_base${CMAKE_SHARED_LIBRARY_SUFFIX}"
         WORKING_DIRECTORY "${LIBRARY_OUTPUT_PATH}")
 endif(NOT MSVC)
 


### PR DESCRIPTION
This works for the C++ bit, but I may have broken some stuff for the python bindings. This separation allows for compiling less code when running benchmarks. It would be great if we could include something along these lines, even if done differently.
