### PR TITLE
Bug fix to load multiple aiScenes into FCL

### DIFF
--- a/src/omplapp/geometry/detail/FCLMethodWrapper.h
+++ b/src/omplapp/geometry/detail/FCLMethodWrapper.h
@@ -301,15 +301,16 @@ namespace ompl
 
                         assert(t.size() % 3 == 0);
 
-                        for (auto & j : t)
+                        for (auto & p : t)
                         {
-                            pts.emplace_back(j[0], j[1], j[2]);
+                            pts.emplace_back(p[0], p[1], p[2]);
                         }
-
-                        for (unsigned int j = 0; j < t.size(); j+=3)
-                            triangles.emplace_back(j, j+1, j+2);
                     }
                 }
+
+                for (unsigned int i = 0; i < pts.size(); i+=3)
+                    triangles.emplace_back(i, i+1, i+2);
+                
                 return std::make_pair(pts, triangles);
             }
 


### PR DESCRIPTION
I don't know if this bug is ever exposed by the current OMPL.app, but I was using it as an example and came across this bug that took me a long time to sort out. I cannot currently test this specific change in OMPL.app, so I'll explain in detail so the PR can be double checked instead.

The function `getFCLModelFromScene` is given a std::vector of `aiScene` meshes from which it prepares the data types necessary to build an `FCL` model. This is specifically a std::vector of 3D points, `Vector3`, and a std::vector of triangles, `fcl::Triangle`. The `Vector3` points are constructed from *x*, *y*, *z* values and the triangles are constructed from three of these points *as defined by indices into the vector of points*.
 
The code currently iterates over each `aiScene` to
1. Get a vector of points from the mesh
```
scene::extractTriangles(scenes[i], t)
```
2. Construct a `Vector3` copy of each point in the `aiScene` mesh *from the (x, y, z) values* and append it to the return vector
```
for (auto & j : t)
{
    pts.emplace_back(j[0], j[1], j[2]);
}
```
3. Construct a `fcl::Triangle` from each consecutive set of three points in the `aiScene` mesh *from indices* and append it to the return vector
```
for (unsigned int j = 0; j < t.size(); j+=3)
    triangles.emplace_back(j, j+1, j+2);
```

The problem is that step 3 iterates over the size of the *current* mesh, i.e., `t`. So when the loop repeats with another `aiScene`, we'll add the new points in step 2 but we won't use those new points for the associated triangles. Instead we will start at 0 and repeat existing triangles.

This behaviour is particularly nasty because when you inspect mesh metrics after loading there'll be the right *number* of triangles. There also won't be any triangles anywhere where they shouldn't be, there'll just be some triangles missing.

An example. If the first `aiScene` had 2 triangles, after one loop we would get something like:
```
pts = [p0, p1, p2, p3, p4, p5]
triangles = [ (0, 1, 2), (3, 4, 5) ]
```
where p0, ..., p5 are `Vector3`s and every (...) index tuple is a `fcl::Triangle`.
If there was a second `aiScene` with 1 triangle, after the second loop we would get something like:
```
pts = [p0, ..., p5, p6, p7 p8]
triangles = [ (0, 1, 2), (3, 4, 5), (0, 1, 2) ]
```
where we've added the new points correctly and we've added a third triangle, but this third triangle is a repeat of the first as we used 'local' indices into a 'global' vector.

The following code fixes this by only assigning the triangle indices once points have been loaded from all the scenes. It assumes that the point lists define consecutive triangles and are mod 3, but the code already asserts that anyway.

I also changed some of the loop variables because all the j's added to my headache.