### PR TITLE
correct gl rotation of start and goal pose

### DIFF
--- a/gui/ompl_app.py
+++ b/gui/ompl_app.py
@@ -889,9 +889,9 @@ class GLViewer(QtOpenGL.QGLWidget):
     def transform(self, pose):
         GL.glPushMatrix()
         GL.glTranslatef(pose[3], pose[4], pose[5])
-        GL.glRotated(pose[0], 1.0, 0.0, 0.0)
-        GL.glRotated(pose[1], 0.0, 1.0, 0.0)
         GL.glRotated(pose[2], 0.0, 0.0, 1.0)
+        GL.glRotated(pose[1], 0.0, 1.0, 0.0)
+        GL.glRotated(pose[0], 1.0, 0.0, 0.0)
     def getTransform(self, xform):
         if hasattr(xform, 'rotation'):
             R = xform.rotation()


### PR DESCRIPTION
the rotation angles are calculated using the Euler ZYX convention (http://web.mit.edu/2.05/www/Handout/HO2.PDF). Thus the rotations should be added in the order of Z-Y-X.