### PR TITLE
Error if missing submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,16 @@ endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
+set(_ompl_cmake_modules_path "${CMAKE_CURRENT_SOURCE_DIR}/ompl/CMakeModules")
+if(NOT EXISTS _ompl_cmake_modules_path)
+    message(FATAL_ERROR "Missing ${_ompl_cmake_modules_path}. Did you check out the submodules?")
+endif()
+
 set(CMAKE_MODULE_PATH
     "${CMAKE_MODULE_PATH}"
     "${CMAKE_ROOT_DIR}/cmake/Modules"
     "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules"
-    "${CMAKE_CURRENT_SOURCE_DIR}/ompl/CMakeModules")
+    "${_ompl_cmake_modules_path}")
 include(GNUInstallDirs)
 include(FeatureSummary)
 include(CompilerSettings)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 set(_ompl_cmake_modules_path "${CMAKE_CURRENT_SOURCE_DIR}/ompl/CMakeModules")
 if(NOT EXISTS _ompl_cmake_modules_path)
-    message(FATAL_ERROR "Missing ${_ompl_cmake_modules_path}. Did you check out the submodules?")
+    message(FATAL_ERROR "Missing ${_ompl_cmake_modules_path}. Did you check out the submodules (\"git submodule update --init --recursive\"?")
 endif()
 
 set(CMAKE_MODULE_PATH


### PR DESCRIPTION
# Purpose

Make it clearer if you forget the submodules

## Before

```
CMake Error at CMakeLists.txt:25 (include):
  include could not find requested file:

    CompilerSettings


CMake Error at CMakeLists.txt:26 (include):
  include could not find requested file:

    OMPLUtils


CMake Warning (dev) at CMakeLists.txt:53 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at CMakeLists.txt:83 (find_boost_python):
  Unknown CMake command "find_boost_python".


-- Configuring incomplete, errors occurred!
```

## After

```
CMake Error at CMakeLists.txt:20 (message):
  Missing /home/ryan/Dev/ompl_ws/omplapp/ompl/CMakeModules.  Did you check
  out the submodules?
```