### PR TITLE
Document ccd dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ OMPL.app has the following required dependencies:
 * [Eigen](http://eigen.tuxfamily.org) (version 3.3 or higher)
 * [Assimp](http://assimp.org) (version 3.0.1270 or higher)
 * [FCL](https://github.com/flexible-collision-library/fcl) (version 0.3.1 or higher)
+* [libccd](https://github.com/danfis/libccd) (version 2.1 or higher)
 
 The following dependencies are optional:
 


### PR DESCRIPTION
ccd was not installed when I built ompl,but it's required for the app. 

```
-- Checking for module 'ccd>=2.0'
--   No package 'ccd' found
CMake Error at /usr/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find ccd (missing: CCD_LIBRARIES CCD_INCLUDE_DIRS)
Call Stack (most recent call first):
  /usr/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  CMakeModules/Findccd.cmake:9 (find_package_handle_standard_args)
  CMakeLists.txt:131 (find_package)
  ```