### PR TITLE
cmake variable reference bugfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 set(_ompl_cmake_modules_path "${CMAKE_CURRENT_SOURCE_DIR}/ompl/CMakeModules")
-if(NOT EXISTS _ompl_cmake_modules_path)
+if(NOT EXISTS "${_ompl_cmake_modules_path}")
     message(FATAL_ERROR "Missing ${_ompl_cmake_modules_path}. Did you check out the submodules (\"git submodule update --init --recursive\"?")
 endif()
 


### PR DESCRIPTION
This issue caused the installation step "cmake ../.." to fail.