### PR TITLE
Fix vcpkg in ci

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   CTEST_OUTPUT_ON_FAILURE: 1
   CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE="C:\tools\vcpkg\scripts\buildsystems\vcpkg.cmake"
   CMAKE_GENERATOR: -G"Visual Studio 15 2017 Win64"
-  VCPKG_ARCH: x64-windows
+  VCPKG_ARCH: x64-windows-release
 
 cache:
   - C:\tools\vcpkg\installed -> .appveyor.yml
@@ -40,7 +40,7 @@ before_build:
   - cmd: git clone -q --depth=1 --branch=main https://github.com/ompl/ompl.git C:\projects\omplapp\ompl
   - cmd: mkdir build
   - cmd: cd build
-  - cmd: cmake %CMAKE_GENERATOR% -DCMAKE_BUILD_TYPE=%configuration% %CMAKE_TOOLCHAIN_FILE% -DOMPL_REGISTRATION=OFF ..
+  - cmd: cmake %CMAKE_GENERATOR% -DCMAKE_BUILD_TYPE=%configuration% %CMAKE_TOOLCHAIN_FILE% -DVCPKG_TARGET_TRIPLET=%VCPKG_ARCH% -DOMPL_REGISTRATION=OFF ..
 
 build:
   project: C:\projects\omplapp\build\omplapp.sln

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,20 +21,23 @@ cache:
 configuration: Release
 
 before_build:
-  - cmd: vcpkg update
-  - cmd: vcpkg install assimp:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-disjoint-sets:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-dynamic-bitset:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-filesystem:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-graph:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-odeint:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-program-options:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-serialization:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-system:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-test:%VCPKG_ARCH%
-  - cmd: vcpkg install boost-ublas:%VCPKG_ARCH%
-  - cmd: vcpkg install eigen3:%VCPKG_ARCH%
-  - cmd: vcpkg install fcl:%VCPKG_ARCH%
+  - cmd: git -C c:\tools\vcpkg\ fetch
+  - cmd: git -C c:\tools\vcpkg\ checkout 2025.04.09
+  - cmd: c:\tools\vcpkg\bootstrap-vcpkg.bat
+  - cmd: vcpkg x-set-installed --triplet %VCPKG_ARCH%
+         assimp
+         boost-disjoint-sets
+         boost-dynamic-bitset
+         boost-filesystem
+         boost-graph
+         boost-odeint
+         boost-program-options
+         boost-serialization
+         boost-system
+         boost-test
+         boost-ublas
+         eigen3
+         fcl
   - cmd: git clone -q --depth=1 --branch=main https://github.com/ompl/ompl.git C:\projects\omplapp\ompl
   - cmd: mkdir build
   - cmd: cd build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,7 @@ environment:
   CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE="C:\tools\vcpkg\scripts\buildsystems\vcpkg.cmake"
   CMAKE_GENERATOR: -G"Visual Studio 15 2017 Win64"
   VCPKG_ARCH: x64-windows-release
+  VCPKG_BINARY_SOURCES: clear
 
 cache:
   - C:\tools\vcpkg\installed -> .appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,6 @@ before_build:
   - cmd: c:\tools\vcpkg\bootstrap-vcpkg.bat
   - cmd: vcpkg x-set-installed --triplet %VCPKG_ARCH%
          assimp
-         boost-disjoint-sets
          boost-dynamic-bitset
          boost-filesystem
          boost-graph


### PR DESCRIPTION
Fix vcpkg in ci:

- Update vcpkg git using tag.
- Remove boost-disjoint-sets from install
- Compile vcpkg ports only in release.
- Use x-set-installed.

appveyor ci is using very old vcpkg. I update it using tag. I don't think is good mythology to be always on master of vcpkg, but to keep on updated tag and updated it when it needed. 

I also remove boost-disjoint-sets. This is discontinue come from boost itself and remove in vcpkg long time ago in https://github.com/microsoft/vcpkg/pull/11221

I also compile vcpkg ports only in release, to save space in cache and compilation time. 

I am using the command x-set-installed instead of update, because this command installs, upgrades, or removes packages and bring them to the latest state as you expected in one command. 
