### PR TITLE
Add github action ci with vcpkg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,21 @@ jobs:
         - os: windows-latest
           triplet: x64-windows-release
           build_type: Release
+          test_target: RUN_TESTS
+          binary_cache: C:\Users\runneradmin\AppData\Local\vcpkg\archives
+          vcpkg_path: C:/vcpkg/installed/vcpkg/info/*
+
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
+
+    - name: Restore cache dependencies
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ matrix.binary_cache }}
+        key: ${{ matrix.os }}
+        restore-keys: ${{ matrix.os }}
 
     - name: "Install dependencies"
       run: >
@@ -43,13 +54,33 @@ jobs:
         fcl
         pkgconf
 
+    - name: copy files for hash
+      shell: bash
+      run: |
+        VCPKG_BASH_PATH=${VCPKG_INSTALLATION_ROOT//\\//}
+        echo $VCPKG_BASH_PATH
+        mkdir -p vcpkg-info
+        find $VCPKG_BASH_PATH/installed/ -type f -name 'vcpkg_abi_info.txt' | \
+        while read filepath; do
+          triplet=$(echo "$filepath" | awk -F/ '{print $(NF-3)}')
+          port=$(echo "$filepath" | awk -F/ '{print $(NF-1)}')
+          cp "$filepath" "vcpkg-info/${triplet}_${port}.txt"
+        done
+
+    - name: Save cache dependencies
+      id: cache-save
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ matrix.binary_cache }}
+        key: ${{ matrix.os }}-${{ hashFiles('vcpkg-info/*') }}
+
     - name: cmake generate
       shell: bash
       run: >
         cmake -B build
         -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
         -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} 
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DOMPL_VERSIONED_INSTALL=OFF
         -DOMPL_BUILD_DEMOS=OFF
         -DOMPL_BUILD_PYBINDINGS=OFF
@@ -64,4 +95,4 @@ jobs:
     - name: test
       shell: bash
       run: |
-        cmake --build build --config ${{ matrix.build_type }} --target RUN_TESTS
+        cmake --build build --config ${{ matrix.build_type }} --target ${{ matrix.test_target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+name: Build & Test
+
+on:
+  pull_request:
+  push:
+    branches:
+     - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  default:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: windows-latest
+          triplet: x64-windows-release
+          build_type: Release
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: "Install dependencies"
+      run: >
+        vcpkg x-set-installed --triplet ${{ matrix.triplet }}
+        assimp
+        boost-dynamic-bitset
+        boost-filesystem
+        boost-graph
+        boost-odeint
+        boost-program-options
+        boost-serialization
+        boost-system
+        boost-test
+        boost-ublas
+        eigen3
+        fcl
+        pkgconf
+
+    - name: cmake generate
+      shell: bash
+      run: >
+        cmake -B build
+        -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+        -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} 
+        -DOMPL_VERSIONED_INSTALL=OFF
+        -DOMPL_BUILD_DEMOS=OFF
+        -DOMPL_BUILD_PYBINDINGS=OFF
+        -DCMAKE_POLICY_DEFAULT_CMP0167=OLD
+        -DOMPL_REGISTRATION=OFF
+
+    - name: cmake build
+      shell: bash
+      run: |
+        cmake --build build --config ${{ matrix.build_type }} --target package
+
+    - name: test
+      shell: bash
+      run: |
+        cmake --build build --config ${{ matrix.build_type }} --target RUN_TESTS


### PR DESCRIPTION
Add github action ci with vcpkg.

I try to fix first the appveyor ci, but it too slow. It take more then 1 hour for install only the minimum dependencies with vcpkg.
I decided to create a new github action ci. template taken from ompl ci, and change according to my knowledge and for ompleapp. 

This is still basic ci that it working. Can improve over time. 
